### PR TITLE
AGRO-3078: Upgrade async lib to 2.6.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,10 +33,17 @@ Finalizer.prototype.wrap = function (func) {
     }.bind(this);
 };
 
+/**
+ * Async 2.0 and above provides the callback argument as the last argument, but we're used to receiving it as the first argument.
+ * Rather than change all of our async.auto calls, we switch the callback to be the first argument here.
+ *
+ * @param {Function} func Original task function
+ * @returns {Function} Wrapped task function
+ */
 Finalizer.prototype.wrap_auto = function (func) {
     return function () {
         var args = Array.prototype.slice.call(arguments);
-        var callback = args.shift();
+        var callback = args.pop();
         if (this.final_callback_called) {
             // this can happen in dependent async.auto() tasks
             return setImmediate(callback, new Error('final callback already called'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe_async",
-  "version": "1.5.2-7",
+  "version": "2.6.4",
   "description": "Provides almost the same interface as async, but where all the callback to the various functions won't be called until all started tasks have finished. Not early exit on error. Also, any limitable function must be limited.",
   "repository": {
     "type": "git",
@@ -8,6 +8,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "async": "^1.5.2"
+    "async": "2.6.4"
   }
 }


### PR DESCRIPTION
* Address async.auto breaking change


See all breaking changes in https://github.com/caolan/async/blob/v2.6.4/CHANGELOG.md#breaking-changes